### PR TITLE
fix package.json exports with correct typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,13 @@
 	"main": "./src/ip2location-io.cjs",
 	"exports": {
 		".": {
-			"import": "./src/wrapper.mjs",
-			"require": "./src/ip2location-io.cjs"
+			"import": {
+				"types": "./src/ip2location-io.d.ts",
+				"default": "./src/wrapper.mjs"
+			},
+			"require": {
+				"default": "./src/ip2location-io.cjs"
+			}
 		}
 	},
 	"types": "src/ip2location-io.d.ts",


### PR DESCRIPTION
Export types for import to let typescript => 4.7 import this package. This fixes the error `error TS7016: Could not find a declaration file for module X implicitly has an ‘any’ type.`